### PR TITLE
Fixed typo in function name get_distance

### DIFF
--- a/US.py
+++ b/US.py
@@ -7,7 +7,7 @@ class US:
         self.echo = echo
         this.readings = [128, 128, 128, 128, 128]
 
-    def get_distanc():
+    def get_distance():
         distance = read_ultrasonic_sensor(trig, echo)
         if (distance != null):
             readings.append(distance)


### PR DESCRIPTION
Changed function name from `get_distanc()` to `get_distance()`.