### PR TITLE
Missing self reference

### DIFF
--- a/US.py
+++ b/US.py
@@ -7,7 +7,7 @@ class US:
         self.echo = echo
         this.readings = [128, 128, 128, 128, 128]
 
-    def get_distanc():
+    def get_distanc( ):
         distance = read_ultrasonic_sensor(trig, echo)
         if (distance != null):
             readings.append(distance)


### PR DESCRIPTION
In a Python class, each function requires a reference to `self` as its first argument/parameter.